### PR TITLE
Missing DB_PASSWORD constant.

### DIFF
--- a/script/run_migrations.rb
+++ b/script/run_migrations.rb
@@ -19,5 +19,5 @@ command += " -M #{migrate_to_version}" if migrate_to_version
 
 puts "Migrating to version #{migrate_to_version}" if migrate_to_version
 
-host_string = "mysql2://#{DB_USER}@#{DB_HOST}/#{DB_NAME}"
+host_string = "mysql2://#{DB_USER}:#{DB_PASSWORD}@#{DB_HOST}/#{DB_NAME}"
 puts `#{command} "#{host_string}"`


### PR DESCRIPTION
Error on running `ruby script/run_migrations.rb`

Error: Sequel::DatabaseConnectionError: Mysql2::Error: Access denied for user 'root'@'localhost' (using password: NO)..

It happens because it's missing `DB_PASSWORD` constant.
