### PR TITLE
HTTPS mixed content warning with google font

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Barkeep</title>
-  <link href='http://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic,700italic' \
+  <link href='//fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic,700italic' \
         rel='stylesheet' type='text/css' />
   <%= @pinion.css_url("/css/styles.css") %>
   <%= @pinion.js_url("/vendor/jquery-1.7.min.js") %>


### PR DESCRIPTION
By using a [protocol-relative URL](http://paulirish.com/2010/the-protocol-relative-url/), mixed content warnings can be avoided when using Barkeep over HTTPS.
