### PR TITLE
Fix TODO about changing saved_search.commits to not return a page number

### DIFF
--- a/models/saved_search.rb
+++ b/models/saved_search.rb
@@ -22,8 +22,7 @@ class SavedSearch < Sequel::Model
           self.method(:select_commits_currently_in_db).to_proc,
       :after => min_commit_date,
       :limit => PAGE_SIZE)
-    page = (result[:count] / PAGE_SIZE).to_i + 1
-    [result[:commits], page, result[:tokens]]
+    [result[:commits], result[:tokens]]
   end
 
   # True if this saved search's results include this commit.

--- a/views/_saved_search.erb
+++ b/views/_saved_search.erb
@@ -8,9 +8,7 @@
  %>
 <%
   min_commit_date = Time.now - 60 * 60 * 24 * current_user.saved_search_time_period
-  # TODO(philc): change saved_search_time_period.commits to not return a page number any more. We now keep
-  # track of the current page number on the client.
-  commits, ignored_page, tokens = saved_search.commits(token, direction, min_commit_date)
+  commits, tokens = saved_search.commits(token, direction, min_commit_date)
   from = tokens[:from]
   to = tokens[:to]
 %>


### PR DESCRIPTION
Minor code cleanup from a TODO in _saved_search.erb
