### PR TITLE
Display top approvers list on stats page. Implements feature requested in issue #292.

### DIFF
--- a/barkeep_server.rb
+++ b/barkeep_server.rb
@@ -404,7 +404,8 @@ class BarkeepServer < Sinatra::Base
       :commented_percent => Stats.num_reviewed_without_lgtm_commits(since).to_f / num_commits,
       :approved_percent => Stats.num_lgtm_commits(since).to_f / num_commits,
       :chatty_commits => Stats.chatty_commits(since),
-      :top_reviewers => Stats.top_reviewers(since)
+      :top_reviewers => Stats.top_reviewers(since),
+      :top_approvers => Stats.top_approvers(since)
     }
   end
 

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -45,7 +45,16 @@ module Stats
     user_ids_and_counts = User.join(:comments, :user_id => :id).
         filter("`comments`.`created_at` > ?", since).
         group_and_count(:users__id).order(:count.desc).limit(10).all
-    users_and_counts = user_ids_and_counts.map do |id_and_count|
+    user_ids_and_counts.map do |id_and_count|
+      [User[id_and_count[:id]], id_and_count[:count]]
+    end
+  end
+
+  def self.top_approvers(since)
+    user_ids_and_counts = User.join(:commits, :approved_by_user_id => :id).
+      filter("`commits`.`approved_at` > ?", since).
+      group_and_count(:users__id).order(:count.desc).limit(10).all
+    user_ids_and_counts.map do |id_and_count|
       [User[id_and_count[:id]], id_and_count[:count]]
     end
   end

--- a/lib/string_helper.rb
+++ b/lib/string_helper.rb
@@ -19,4 +19,9 @@ module StringHelper
   def self.short_date(time)
     time.strftime "%b %d, %Y"
   end
+
+  def self.pluralize(count, singular, plural = nil)
+    text = (count == 1) ? singular : (plural || "#{singular}s")
+    "#{count} #{text}"
+  end
 end

--- a/public/css/styles.scss
+++ b/public/css/styles.scss
@@ -431,6 +431,27 @@ table.commitsList, table.authorList {
       }
 
       .commitsList { width: $pageWidth; }
+
+      &.topApprovers {
+        width: 100%;
+
+        .authorList {
+          width: $pageWidth;
+
+          td.author {
+            padding-right: 30px;
+          }
+          td.email {
+            color: $lightTextColor;
+            font-size: 90%;
+            text-align: right;
+          }
+          td.count {
+            width: 100%;
+            color: $lightTextColor;
+          }
+        }
+      }
     }
   }
 }

--- a/views/_commit_line.erb
+++ b/views/_commit_line.erb
@@ -27,8 +27,7 @@
   <td class="commentCount">
     <% comment_count = db_commit.comment_count %>
     <% if comment_count > 0 %>
-      <% comment_count_hover_text = "#{comment_count} comment#{'s' unless comment_count == 1}" %>
-      <a class="noLink west" rel="tipsy" title="<%= comment_count_hover_text %>">
+      <a class="noLink west" rel="tipsy" title="<%= StringHelper.pluralize(comment_count, "comment") %>">
         <span><%= comment_count %></span><img src="/assets/images/comment_bubble.png" />
       </a>
     <% end %>

--- a/views/stats.erb
+++ b/views/stats.erb
@@ -29,7 +29,7 @@
               <a href="mailto:<%= user.email %>" rel="tipsy" class="west" title="<%= user.email %>">
                 <%= user.name[0..25] %></a>
             </td>
-            <td class="count">with <%= count %> comments</td>
+            <td class="count">with <%= StringHelper.pluralize(count, "comment") %></td>
             <td class="email">
               <a href="mailto:<%= user.email %>" rel="tipsy" class="east" title="Email"><%= user.email %>
             </a>
@@ -56,6 +56,27 @@
       <table class="commitsList">
         <% chatty_commits.each do |commit, count| %>
           <%= erb :_commit_line, :layout => false, :locals => { :commit => commit } %>
+        <% end %>
+      </table>
+    </div>
+    <div class="statistic topApprovers">
+      <div class="header"><div class="name">Top Approvers</div></div>
+      <table class="authorList">
+        <% top_approvers.each do |user, count| %>
+            <tr>
+              <td class="avatarCell">
+                <img class="avatar" src="<%= user.gravatar %>"/>
+              </td>
+              <td class="author">
+                <a href="mailto:<%= user.email %>" rel="tipsy" class="west" title="<%= user.email %>">
+                  <%= user.name[0..25] %></a>
+              </td>
+              <td class="count">with <%= StringHelper.pluralize(count, "approved commit") %></td>
+              <td class="email">
+                <a href="mailto:<%= user.email %>" rel="tipsy" class="east" title="Email"><%= user.email %>
+                </a>
+              </td>
+            </tr>
         <% end %>
       </table>
     </div>


### PR DESCRIPTION
Also added StringHelper.pluralize helper method. Use on stats page where applicable.
