### PR TITLE
Comment box won't properly close after input is entered

### DIFF
--- a/public/coffee/commit.coffee
+++ b/public/coffee/commit.coffee
@@ -121,8 +121,8 @@ window.Commit =
         # Don't attempt to search if the input value ends with a comma and whitespace.
         false if $("#authorInput").val().match(/,\s*$/)
 
-  pluralize: (count, singular, plural = nil) ->
-    text = (count == 1) ? singular : (plural || "#{singular}s")
+  pluralize: (count, singular, plural) ->
+    text = if count == 1 then singular else (plural || "#{singular}s")
     "#{count} #{text}"
 
   calculateMarginSize: ->


### PR DESCRIPTION
When trying to add a new comment to a diff and pressing "Post your comment" the following javascript error will be thrown, without properly closing the box:

Uncaught ReferenceError: nil is not defined 

This is due to an error in the method pluralize at commit.coffee / commit.js, where a default parameter is given as nil; that keyword nil is considered a regular javascript variable but won't be found in that context, resulting in the error above. 
The comment itself is added successfully, though.

In order to fix this I just removed the default parameter value and also used a regular 'if' within that method since it seems ternary operators are not supported by coffeescript.
