### PR TITLE
Fix for issue ooyala/barkeep#285

### DIFF
--- a/lib/emails.rb
+++ b/lib/emails.rb
@@ -138,8 +138,9 @@ class Emails
   # Sends an email using Pony.
   # pony_options: extra options to pass through to Pony. Used for setting mail headers like
   # "message-ID" to enable threading.
+  # Subject forced to utf-8 to avoid issues with mail encodings (ooyala/barkeep#285)
   def self.deliver_mail(to, subject, html_body, pony_options = {})
-    options = { :to => to, :via => :smtp, :subject => subject, :html_body => html_body,
+    options = { :to => to, :via => :smtp, :subject => subject.force_encoding("utf-8"), :html_body => html_body,
       # These settings are from the Pony documentation and work with Gmail's SMTP TLS server.
       :via_options => {
         :address => "smtp.gmail.com",


### PR DESCRIPTION
Hi,

I was dealing with the same issue as described in #285 because my Google first and last name both have special chars (á and ó respectively).

In my case, there was no issue with the from or to address as barkeep latest version does not use user firstname or lastname either in the from or destination address. 

However, it does use the user names inside subject, and that was the reason I was unable to get any email out, failing always with:
"Encoding::UndefinedConversionError "\xC3" from ASCII-8BIT to UTF-8..."

This patch forces the subject to be sent in utf-8 no matter what charset data currently has, as data is taken from Google I don't expect this to be a problem with most users.
