### PR TITLE
Message search

### DIFF
--- a/lib/meta_repo.rb
+++ b/lib/meta_repo.rb
@@ -357,6 +357,8 @@ class MetaRepo
 
     git_options[:after] = search_options[:after] unless search_options[:after].blank?
 
+    git_options[:grep] = search_options[:grep] unless search_options[:grep].blank?
+
     git_arguments = search_options[:branches].blank? ? [] :
         search_options[:branches].map { |name| "origin/#{name}" }
     git_options[:all] = true if git_arguments.empty?

--- a/models/saved_search.rb
+++ b/models/saved_search.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # A saved search represents a list of commits, some read and some unread.
 #
 # Columns:

--- a/models/saved_search.rb
+++ b/models/saved_search.rb
@@ -51,6 +51,7 @@ class SavedSearch < Sequel::Model
     message << "by #{comma_separated_list(map_authors_names(authors_list))}" unless authors_list.empty?
     message << "in #{comma_separated_list(paths_list)}" unless paths_list.empty?
     message << "on #{comma_separated_list(branches_list)}" unless branches_list.empty?
+    message << "containing ‘#{messages}’" unless messages.nil? || messages.empty?
     unless repos_list.empty?
       message << "in the #{comma_separated_list(repos_list)} #{english_quantity("repo", repos_list.size)}"
     end

--- a/models/saved_search.rb
+++ b/models/saved_search.rb
@@ -15,6 +15,7 @@ class SavedSearch < Sequel::Model
       :branches => branches_list,
       :authors => authors_list,
       :paths => paths_list,
+      :grep => messages,
       :token => token,
       :direction => direction,
       :commit_filter_proc => self.unapproved_only ?

--- a/public/coffee/smart_search.coffee
+++ b/public/coffee/smart_search.coffee
@@ -8,8 +8,9 @@ class window.SmartSearch
     author: "authors"
     branch: "branches"
     repo: "repos"
+    message: "messages"
 
-  KEYS = ["repos:", "authors:", "paths:", "branches:"]
+  KEYS = ["repos:", "authors:", "paths:", "branches:", "messages:"]
 
   # fetches autocomplete suggestions and returns it through the onSuggestionReceived callback with an array of
   # labels and values


### PR DESCRIPTION
I have added filtering by commit message (#324). There are no tests yet and it can only search for one word, but I would like to know whether I am on the right track with this.

I only want to filter by issue reference, would it even be necessary to support searching for more than one word? That would require parsing of double quotes (messages: "foo bar").