### PR TITLE
Add README about how to use barkeep without vagrant VM

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,6 +24,8 @@ You can shut it all down later using `bundle exec vagrant halt`.
 Once you decide to use Barkeep for your team, you should deploy it to an Ubuntu web server. See the [Deploying
 Barkeep](https://github.com/ooyala/barkeep/wiki/Deploying-Barkeep) wiki page for more information.
 
+Read `RUN-WITHOUT-VM.markdown` quick standalone instructions.
+
 ### Docs
 
 See **[the wiki](https://github.com/ooyala/barkeep/wiki)** for instructions on setting up Barkeep for

--- a/RUN-WITHOUT-VM.markdown
+++ b/RUN-WITHOUT-VM.markdown
@@ -1,0 +1,41 @@
+Running Barkeep standalone
+==========================
+
+While most barkeep development happens in a Vagrant VM, you can also run barkeep normally, without a VM.
+
+
+Installation
+------------
+
+Install `rbenv` and make sure you have the version specified in `.rbenv` installed and set up.
+
+Install redis.
+
+Install a MySQL server, set up a user/database with all permissions (they are usually called `barkeep`/`barkeep`).
+
+Run `bundle install` to install barkeep's dependencies.
+
+Edit `environment.rb` and set variables like `db_user` according to your DB setup.
+
+Run `script/run_migrations.rb` to initialize the database.
+
+If you wish to have the demo user, run `script/create_demo_user.rb`.
+
+
+Startup
+-------
+
+Run these programs at the same time:
+
+```bash
+# Start webserver
+
+bin/run_app.bash
+
+# Start daemons:
+# - resque: background jobs system
+# - clockwork: cron-like daemon responsible for fetching commits
+
+script/run_resque.rb
+script/run_clockwork.rb
+```


### PR DESCRIPTION
I found quite hard to set up an actual barkeep installation on my server (running a VM on it doesn't really make sense).

This commit adds an quick start readme telling which commands to run for a standalone server.
