### PR TITLE
Un-configure repos when initializing

### DIFF
--- a/lib/script_environment.rb
+++ b/lib/script_environment.rb
@@ -23,5 +23,7 @@ BacktraceShortener.monkey_patch_the_exception_class! unless ENV["RACK_ENV"] == "
 unless ENV["RACK_ENV"] == "test"
   logger = Logger.new(STDOUT)
   logger.level = Logger::DEBUG
-  MetaRepo.configure(logger, REPOS_ROOT)
+  unless ENV["BARKEEP_INIT"] == "true"
+    MetaRepo.configure(logger, REPOS_ROOT)
+  end
 end

--- a/script/initial_app_setup.rb
+++ b/script/initial_app_setup.rb
@@ -16,6 +16,8 @@ require "terraform/dsl"
 include Terraform::DSL
 require "environment.rb"
 
+ENV["BARKEEP_INIT"] = "true"
+
 def mysql_command() @mysql_command ||= (`which mysql || which mysql5`).chomp end
 def mysqladmin_command() @mysql_admin ||= (`which mysqladmin || which mysqladmin5`).chomp end
 def db_exists?(db_name)


### PR DESCRIPTION
An error occurs when initializing (running `script/initial_app_setup.rb`)

```
$ ./script/initial_app_setup.rb 
* Dependency create mysql barkeep database is not met. Meeting it.
* Dependency run task once: database migrations is not met. Meeting it.
/home/s1n4/Code/barkeep/lib/models.rb:4: warning: already initialized constant DB
Error: Sequel::DatabaseError: Mysql2::Error: Table 'barkeep.git_repos' doesn't exist.../gems/sequel-3.36.1/lib/sequel/adapters/mysql2.rb:89:in `query'
.../gems/sequel-3.36.1/lib/sequel/adapters/mysql2.rb:89:in `query': Mysql2::Error: Table 'barkeep.git_repos' doesn't exist (Sequel::DatabaseError)
    from .../gems/sequel-3.36.1/lib/sequel/adapters/mysql2.rb:89:in `block in _execute'
    from .../gems/sequel-3.36.1/lib/sequel/database/logging.rb:33:in `log_yield'
    from .../gems/sequel-3.36.1/lib/sequel/adapters/mysql2.rb:89:in `_execute'
    from .../gems/sequel-3.36.1/lib/sequel/adapters/shared/mysql_prepared_statements.rb:23:in `block in execute'
    from .../gems/sequel-3.36.1/lib/sequel/database/connecting.rb:229:in `block in synchronize'
    from .../gems/sequel-3.36.1/lib/sequel/connection_pool/threaded.rb:105:in `hold'
    from .../gems/sequel-3.36.1/lib/sequel/database/connecting.rb:229:in `synchronize'
    from .../gems/sequel-3.36.1/lib/sequel/adapters/shared/mysql_prepared_statements.rb:23:in `execute'
    from .../gems/sequel-3.36.1/lib/sequel/dataset/actions.rb:744:in `execute'
    from .../gems/sequel-3.36.1/lib/sequel/adapters/mysql2.rb:171:in `execute'
    from .../gems/sequel-3.36.1/lib/sequel/adapters/mysql2.rb:147:in `fetch_rows'
    from .../gems/sequel-3.36.1/lib/sequel/dataset/actions.rb:131:in `each'
    from .../gems/sequel-3.36.1/lib/sequel/dataset/actions.rb:515:in `single_record'
    from .../gems/sequel-3.36.1/lib/sequel/dataset/actions.rb:188:in `first'
    from .../gems/sequel-3.36.1/lib/sequel/model/base.rb:307:in `find'
    from .../gems/sequel-3.36.1/lib/sequel/model/base.rb:323:in `find_or_create'
    from /home/s1n4/Code/barkeep/lib/meta_repo.rb:47:in `block in load_repos'
    from /home/s1n4/Code/barkeep/lib/meta_repo.rb:44:in `each'
    from /home/s1n4/Code/barkeep/lib/meta_repo.rb:44:in `load_repos'
    from /home/s1n4/Code/barkeep/lib/meta_repo.rb:31:in `initialize'
    from /home/s1n4/Code/barkeep/lib/meta_repo.rb:22:in `new'
    from /home/s1n4/Code/barkeep/lib/meta_repo.rb:22:in `configure'
    from /home/s1n4/Code/barkeep/lib/script_environment.rb:26:in `<top (required)>'
    from script/create_demo_user.rb:9:in `require'
    from script/create_demo_user.rb:9:in `<main>'
```

It happens while `REPOS_ROOT` directory is existing with some repo, so repos configuration causes that.
