### PR TITLE
Fix review request sending

### DIFF
--- a/lib/emails.rb
+++ b/lib/emails.rb
@@ -175,7 +175,7 @@ class Emails
 
   # The email body for review request emails.
   def self.review_request_email_body(commit, requester)
-    render_template("review_request_email.erb", :commit => commit, :requestor => requestor)
+    render_template("review_request_email.erb", :commit => commit, :requester => requester)
   end
 
   # The email body for comment emails.


### PR DESCRIPTION
This fixes a "requester"/"requestor" switch in lib/emails.rb, introduced in 82c7a9f97, that prevents review request emails from being sent.

This probably deserves an integration test, but I'm a too busy right now.

Best,
Mike
