### PR TITLE
Make the redis and resque databases configurable

### DIFF
--- a/environment.rb
+++ b/environment.rb
@@ -17,6 +17,8 @@ BARKEEP_HOSTNAME = "localhost:8040"
 
 REDIS_HOST = "localhost"
 REDIS_PORT = 6379
+REDIS_DB   = 0
+RESQUE_DB  = 1
 
 # A comma-separate list of OpenID provider URLs for signing in your users.
 # If you provide more than one, users will receive a UI allowing to pick which service to use to authenticate.

--- a/lib/redis_manager.rb
+++ b/lib/redis_manager.rb
@@ -6,7 +6,8 @@ class RedisManager
   def self.redis_instance
     return @@redis if @@redis
     begin
-      @@redis = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT)
+      @@redis = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT,
+                          :db => REDIS_DB)
       timeout(4) { @@redis.ping }
     rescue Timeout::Error
       warn "Timed out while connecting to Redis."

--- a/lib/script_environment.rb
+++ b/lib/script_environment.rb
@@ -17,6 +17,9 @@ require "redis"
 require "lib/redis_manager"
 require "backtrace_shortener"
 
+Resque.redis = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT,
+                         :db => RESQUE_DB)
+
 # Make the developer experience better by shortening backtraces.
 BacktraceShortener.monkey_patch_the_exception_class! unless ENV["RACK_ENV"] == "production"
 


### PR DESCRIPTION
Hello, 

I noticed that Barkeep doesn't play well with other applications that use Resque to perform jobs asynchronously. Workers of those apps show up in Barkeep's resque web interface and vice versa. Jobs being enqueued might end up being processed by those workers, which results in errors.

Therefore, I thought it might be a good idea to make the Redis and Resque database configurable in environment.rb. I added some sane defaults, though.

What do you guys think?
