### PR TITLE
Remove Nokogiri from the test group since it's required for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ gem "therubyracer"
 gem "terraform"
 
 gem "nokogiri"
+gem "fezzik"
 
 group :test do
   # NOTE(caleb): require rr >= 1.0.3 and scope >= 0.2.3 for mutual compatibility
@@ -82,7 +83,6 @@ group :test do
 end
 
 group :development do
-  gem "fezzik"
   gem "pry"
   gem "awesome_print"
   gem "vagrant", "~> 1.0.5" # For testing deployments


### PR DESCRIPTION
Hello,

I removed 'nokogiri' from the test group in the `Gemfile` because it's explicitly required in `barkeep_server.rb` and thus bundling gems with '--without development test' isn't working.
