### PR TITLE
Fix vagrant_quick_start.rb failure when ~/.ssh/config doesn't exist

### DIFF
--- a/script/setup_vagrant.rb
+++ b/script/setup_vagrant.rb
@@ -32,6 +32,7 @@ end
 
 def setup_ssh_config
   ssh_config_path = File.expand_path("~/.ssh/config")
+  FileUtils.touch(ssh_config_path)
 
   unless File.read(ssh_config_path).include?(hostname)
     # Create an entry in our ~/.ssh/config which allows us to ssh into this vagrant box by hostname.


### PR DESCRIPTION
I am not a solid Ruby programmer, so if FileUtils.touch is the wrong way to go about this then please let me know.
