### PR TITLE
Support for other issue trackers

### DIFF
--- a/environment.rb
+++ b/environment.rb
@@ -41,3 +41,13 @@ RESQUE_WORKERS = 2
 # A comma-separated list of permitted users, to restrict access to barkeep. If unset, any user can log in
 # via their Gmail account. This feature is a work in progress and not ready for general use; see #361.
 PERMITTED_USERS = ""
+
+# Github is the default issue tracker
+ISSUE_TRACKER = Proc.new do |username, repo, number|
+  "https://github.com/#{username}/#{repo}/issues/#{number}"
+end
+
+# Example for Redmine usage
+# ISSUE_TRACKER = Proc.new do |username, repo, number|
+#   "https://redmine.example.com/issues/#{number}"
+# end

--- a/lib/filters.rb
+++ b/lib/filters.rb
@@ -49,12 +49,11 @@ end
 
 # See https://github.com/blog/831-issues-2-0-the-next-generation
 # for the list of issue linking synonyms.
-StringFilter.define_filter :link_github_issue do |str, github_username, github_repo|
+StringFilter.define_filter :link_to_issue_tracker do |str, username, repo|
   str.gsub(/(#|gh-)(\d+)/i) do
     prefix = Regexp.last_match(1)
     number = Regexp.last_match(2)
-    "<a href='https://github.com/#{github_username}/#{github_repo}/issues/#{number}' target='_blank'>" +
-        "#{prefix}#{number}</a>"
+    "<a href='#{ISSUE_TRACKER.call(username, repo, number)}' target='_blank'>#{prefix}#{number}</a>"
   end
 end
 

--- a/models/commit.rb
+++ b/models/commit.rb
@@ -20,7 +20,7 @@ class Commit < Sequel::Model
   end
   add_filter(:message) { |message| StringFilter.newlines_to_html(message) }
   add_filter(:message) do |message, commit|
-    StringFilter.link_github_issue(message, "ooyala", commit.git_repo.name)
+    StringFilter.link_to_issue_tracker(message, "ooyala", commit.git_repo.name)
   end
   add_filter(:message) { |message| StringFilter.link_jira_issue(message) }
   add_filter(:message) { |message| StringFilter.emoji(message) }

--- a/test/unit/string_filter_test.rb
+++ b/test/unit/string_filter_test.rb
@@ -43,7 +43,7 @@ class StringFilterTest < Scope::TestCase
     end
 
     should "link github issue" do
-      filtered = StringFilter.link_github_issue("issue #42", "ooyala", "test_repo")
+      filtered = StringFilter.link_to_issue_tracker("issue #42", "ooyala", "test_repo")
       assert filtered.include?("github.com/ooyala/test_repo/issues/42")
     end
 


### PR DESCRIPTION
I added support for other issue trackers besides GitHub. The URL is completely configurable through `environment.rb` and I kept the current defaults (github.com/ooyala/...).