### PR TITLE
Remove default encoding from Pygments call

### DIFF
--- a/lib/syntax_highlighter.rb
+++ b/lib/syntax_highlighter.rb
@@ -38,7 +38,7 @@ class SyntaxHighlighter
   def self.pygmentize(file_type, text)
     file_type = "text" if Pygments::Lexer.find_by_alias(file_type).nil?
     Pygments.highlight(text, :lexer => file_type, :options => {
-      :encoding => "utf-8", :nowrap => true, :stripnl => false, :stripall => false
+      :nowrap => true, :stripnl => false, :stripall => false
     })
   end
 


### PR DESCRIPTION
Currently only UTF-8 encoded repositories are supported by Barkeep.

This tiny commit seems to solve all issues with other encodings, for example ISO-8859-1. Apparently, Pygments decides which encoding to use and no exceptions are raised when viewing diffs in non-UTF-8 encoded repositories.

Can anyone confirm that this the way to go? I'm not quite sure if there's a better way to handle those issues. I tried to get the encoding from the actual diff that is passed to Pygments, but that didn't work for me at all.