### PR TITLE
Add ability to approve commits via API calls

### DIFF
--- a/barkeep_server.rb
+++ b/barkeep_server.rb
@@ -160,7 +160,7 @@ class BarkeepServer < Sinatra::Base
     def ensure_required_params(*required_params)
       required_params.each do |param|
         unless params[param] && !params[param].strip.empty?
-          message = "Missing required parameter '{param}'."
+          message = "Missing required parameter '#{param}'."
           if content_type == "application/json"
             halt 400, { :error => message }.to_json
           else

--- a/lib/api_routes.rb
+++ b/lib/api_routes.rb
@@ -13,7 +13,7 @@ class BarkeepServer < Sinatra::Base
   end
 
   # API routes that don't require authentication
-  AUTHENTICATION_WHITELIST_ROUTES = ["/api/commits/"]
+  AUTHENTICATION_WHITELIST_ROUTES = { :get => ['/api/commits/'] }
   # API routes that require admin
   ADMIN_ROUTES = ["/api/add_repo"]
   # How out of date an API call may be before it is rejected
@@ -21,7 +21,11 @@ class BarkeepServer < Sinatra::Base
 
   before "/api/*" do
     content_type :json
-    next if AUTHENTICATION_WHITELIST_ROUTES.any? { |route| request.path =~ /^#{route}/ }
+    method = request.request_method.downcase.to_sym
+    next if AUTHENTICATION_WHITELIST_ROUTES.has_key?(method) && \
+            AUTHENTICATION_WHITELIST_ROUTES[method].any? do |route|
+      request.path =~ /^#{route}/
+    end
     user = ensure_properly_signed(request, params)
     if ADMIN_ROUTES.any? { |route| request.path =~ /^#{route}/ }
       api_error 403, "Admin only." unless user.admin?
@@ -59,19 +63,28 @@ class BarkeepServer < Sinatra::Base
     format_commit_data(commit, params[:repo_name], fields).to_json
   end
 
-  post "/api/approve/:repo_name/:sha" do
+  # TODO: use patch instead of post
+  post "/api/commits/:repo_name/:sha" do
     begin
       commit = Commit.prefix_match params[:repo_name], params[:sha]
-      commit.approve(current_user)
+      case params[:approved]
+      when 'true'
+        commit.approve(current_user)
+      when 'false'
+        commit.disapprove
+      else
+        raise "Missing parameter 'approved'"
+      end
       status 204
     rescue RuntimeError => e
       api_error 404, e.message
     end
   end
 
-  # NOTE(caleb): Large GET requests are rejected by the Ruby web servers we use. (Unicorn, in particular,
-  # doesn't seem to like paths > 1k and rejects them silently.) Hence, to batch-request commit data, we must
-  # use a POST.
+  # NOTE(caleb): Large GET requests are rejected by the Ruby web servers we
+  #              use. (Unicorn, in particular, doesn't seem to like paths > 1k
+  #              and rejects them silently.) Hence, to batch-request commit
+  #              data, we must use a POST.
   post "/api/commits/:repo_name" do
     shas = params[:shas].split(",")
     fields = params[:fields] ? params[:fields].split(",") : nil

--- a/lib/api_routes.rb
+++ b/lib/api_routes.rb
@@ -22,7 +22,7 @@ class BarkeepServer < Sinatra::Base
   before "/api/*" do
     content_type :json
     method = request.request_method.downcase.to_sym
-    next if AUTHENTICATION_WHITELIST_ROUTES.has_key?(method) && \
+    next if AUTHENTICATION_WHITELIST_ROUTES.has_key?(method) &&
             AUTHENTICATION_WHITELIST_ROUTES[method].any? do |route|
       request.path =~ /^#{route}/
     end

--- a/lib/api_routes.rb
+++ b/lib/api_routes.rb
@@ -59,6 +59,16 @@ class BarkeepServer < Sinatra::Base
     format_commit_data(commit, params[:repo_name], fields).to_json
   end
 
+  post "/api/approve/:repo_name/:sha" do
+    begin
+      commit = Commit.prefix_match params[:repo_name], params[:sha]
+      commit.approve(current_user)
+      status 204
+    rescue RuntimeError => e
+      api_error 404, e.message
+    end
+  end
+
   # NOTE(caleb): Large GET requests are rejected by the Ruby web servers we use. (Unicorn, in particular,
   # doesn't seem to like paths > 1k and rejects them silently.) Hence, to batch-request commit data, we must
   # use a POST.

--- a/lib/api_routes.rb
+++ b/lib/api_routes.rb
@@ -14,7 +14,8 @@ class BarkeepServer < Sinatra::Base
 
   # API routes that don't require authentication. This is a Hash with the HTTP
   # verb as key and an array of path fragments as value
-  AUTHENTICATION_WHITELIST_ROUTES = { :get => ['/api/commits/'] }
+  AUTHENTICATION_WHITELIST_ROUTES = { :get => ['/api/commits/'],
+                                      :post => ['/api/commits/my_repo'] }
   # API routes that require admin
   ADMIN_ROUTES = ["/api/add_repo"]
   # How out of date an API call may be before it is rejected

--- a/lib/api_routes.rb
+++ b/lib/api_routes.rb
@@ -12,7 +12,8 @@ class BarkeepServer < Sinatra::Base
     end
   end
 
-  # API routes that don't require authentication
+  # API routes that don't require authentication. This is a Hash with the HTTP
+  # verb as key and an array of path fragments as value
   AUTHENTICATION_WHITELIST_ROUTES = { :get => ['/api/commits/'] }
   # API routes that require admin
   ADMIN_ROUTES = ["/api/add_repo"]

--- a/test/unit/api_test.rb
+++ b/test/unit/api_test.rb
@@ -129,7 +129,7 @@ class ApiTest < Scope::TestCase
         OpenSSL::HMAC.hexdigest "sha1", "apisecret", "POST #{create_request_url(path, params)}"
       end
 
-      def post_commit_approval(status)
+      def perform_commit_approval_request(status)
         # Attention: approved=true can't be appended here directly, since the
         #            the signature generation requires lexicographical sorting
         path = "/api/commits/my_repo/sha1"
@@ -142,20 +142,20 @@ class ApiTest < Scope::TestCase
 
       should "return 204 on successful approval" do
         stub_commit("sha1", @user)
-        post_commit_approval("true")
+        perform_commit_approval_request("true")
         assert_status 204
       end
 
       should "return 204 on successful disapproval" do
         commit = stub_commit("sha1", @user)
         commit.approve(@user)
-        post_commit_approval("false")
+        perform_commit_approval_request("false")
         assert_status 204
       end
 
       should "return 404 for incorrect approval parameters" do
         stub_commit("sha1", @user)
-        post_commit_approval("foo")
+        response = perform_commit_approval_request("foo")
         assert_status 404
       end
     end

--- a/test/unit/api_test.rb
+++ b/test/unit/api_test.rb
@@ -95,7 +95,11 @@ class ApiTest < Scope::TestCase
     setup do
       # Temporarily make every api route require authentication
       @whitelist_routes = BarkeepServer::AUTHENTICATION_WHITELIST_ROUTES.dup
-      @whitelist_routes.each { |route| BarkeepServer::AUTHENTICATION_WHITELIST_ROUTES.delete route }
+      @whitelist_routes.keys.each do |method|
+        @whitelist_routes[method].each do |route|
+          BarkeepServer::AUTHENTICATION_WHITELIST_ROUTES[method].delete route
+        end
+      end
 
       approved_commit = stub_commit("sha1", @user)
       stub_many approved_commit, :approved_by_user_id => 42, :approved_by_user => @user, :comment_count => 155
@@ -108,7 +112,11 @@ class ApiTest < Scope::TestCase
     end
 
     teardown do
-      @whitelist_routes.each { |route| BarkeepServer::AUTHENTICATION_WHITELIST_ROUTES << route }
+      @whitelist_routes.keys.each do |method|
+        @whitelist_routes[method].each do |route|
+          BarkeepServer::AUTHENTICATION_WHITELIST_ROUTES[:method] << route
+        end
+      end
     end
 
     should "return proper result for up-to-date, correctly signed request" do


### PR DESCRIPTION
This adds the ability to approve commits through API POST requests.