### PR TITLE
Add ALWAYS_EMAIL_COMMENTS_TO_COMMITER setting

### DIFF
--- a/environment.prod.rb
+++ b/environment.prod.rb
@@ -18,3 +18,4 @@ GMAIL_PASSWORD = "password!"
 COOKIE_SESSION_SECRET = "This should be a long, random, secret string."
 REDIS_DB = 0
 REDIS_DB_FOR_RESQUE = 1
+ALWAYS_EMAIL_COMMENTS_TO_COMMITER = false

--- a/environment.prod.sh
+++ b/environment.prod.sh
@@ -18,3 +18,4 @@ export GMAIL_PASSWORD="password!"
 export COOKIE_SESSION_SECRET="This should be a long, random, secret string."
 export REDIS_DB="0"
 export REDIS_DB_FOR_RESQUE="1"
+export ALWAYS_EMAIL_COMMENTS_TO_COMMITER=false

--- a/environment.rb
+++ b/environment.rb
@@ -41,3 +41,7 @@ RESQUE_WORKERS = 2
 # A comma-separated list of permitted users, to restrict access to barkeep. If unset, any user can log in
 # via their Gmail account. This feature is a work in progress and not ready for general use; see #361.
 PERMITTED_USERS = ""
+
+# If set to true, comments to a commit will be sent to the author email even if a user with such email
+# does not exists in user database
+ALWAYS_EMAIL_COMMENTS_TO_COMMITER = false

--- a/lib/emails.rb
+++ b/lib/emails.rb
@@ -57,7 +57,7 @@ class Emails
     all_previous_commenters = commit.comments.map(&:user).reject(&:demo?).reject(&:deleted?)
     author = commit.grit_commit.author
     user = User.find(:email => author.email)
-    to << author.email if user && !user.deleted?
+    to << author.email if ALWAYS_EMAIL_COMMENTS_TO_COMMITER || (user && !user.deleted?)
     # There shouldn't be deleted users with saved searches, but filter them out just in case.
     cc = (users_with_saved_searches_matching(commit, :email_comments => true).reject(&:deleted?) +
           all_previous_commenters).map(&:email).uniq


### PR DESCRIPTION
Issue described here: 

https://github.com/ooyala/barkeep/issues/426

I propose adding a setting - ALWAYS_EMAIL_COMMENTS_TO_COMMITER
(defaults to false) to send comment emails to the git commit author email ALWAYS (disregarding whether a user exists or not in the "users" table.