### PR TITLE
Showing first 80 characters of commit message in HTML title

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Barkeep</title>
+  <title><% if defined?(commit) %><%= commit.message[0...80] %> | <% end %>Barkeep</title>
   <link href='//fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic,700italic' \
         rel='stylesheet' type='text/css' />
   <%= css_url("/css/styles.css") %>


### PR DESCRIPTION
I often scroll down long commits and then ask myself "Wait, what was this commit supposed to do?" - In this case it would be cool to quickly read the commit message again.

Also: When having many commits open in many tabs, they are all just called "Barkeep" And it is impossible to distinguish them. By showing the commit message in the HTML title, we can easier navigate the many tabs in the browser.
