### PR TITLE
Fixing error: NoMethodError - undefined method `gsub' for nil:NilClass

### DIFF
--- a/lib/syntax_highlighter.rb
+++ b/lib/syntax_highlighter.rb
@@ -47,7 +47,9 @@ class SyntaxHighlighter
   # NOTE(caleb): It might be possible/better to do this in Python. However, that will probably involve
   # modifying Pygments (monkey-patching isn't so simple in Python) and in general will be more work.
   def self.global_highlighting(pygmentized_text)
-    pygmentized_text.gsub(/[ \t]+$/) { |whitespace| "<span class='trailingWhitespace'>#{whitespace}</span>" }
+    unless pygmentized_text.nil?
+      pygmentized_text.gsub(/[ \t]+$/) { |whitespace| "<span class='trailingWhitespace'>#{whitespace}</span>" }
+    end
   end
 
   def self.redis_cache_key(repo_name, blob)


### PR DESCRIPTION
I was getting an error in lib/syntax_highlighter.rb where 
```ruby
SyntaxHighlighter.pygmentize(file_type, blob.data)
```
was returning nil and thus throwing an error in
```ruby
def self.global_highlighting(pygmentized_text)
```
when it tried to call the gsub method on the nil object.

I'm primarily a PHP developer so please feel free to school me on Ruby methodologies that I may have screwed up.