### PR TITLE
Bugfix for the number of unreviewed commits

### DIFF
--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -13,8 +13,7 @@ module Stats
   end
 
   def self.num_unreviewed_commits(since)
-    Commit.filter("`commits`.`date` > ?", since).
-        left_join(:comments, :commit_id => :commits__id).filter(:comments__id => nil).count
+    Commit.filter("`commits`.`date` > ?", since).filter("approved_by_user_id IS NULL").count
   end
 
   def self.num_reviewed_without_lgtm_commits(since)


### PR DESCRIPTION
num_unreviewed_commits was doing something different than indicated - counting the number of commits without comments. 

Now it simply counts the number of commits that have a null approved_by_user_id.
