### PR TITLE
Add name field to Add new repo tool

### DIFF
--- a/lib/admin_routes.rb
+++ b/lib/admin_routes.rb
@@ -101,7 +101,7 @@ class BarkeepServer < Sinatra::Base
   post "/admin/repos/create_new_repo" do
     halt 400, "'url' is required." if (params[:url] || "").strip.empty?
     begin
-      add_repo params[:url]
+      add_repo params[:url], params[:name]
     rescue RuntimeError => e
       halt 400, e.message
     end

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -7,9 +7,13 @@ require "uri"
 require "resque_jobs/clone_new_repo"
 
 module Api
-  def add_repo(url)
+  def add_repo(url,name)
     raise "This is not a valid URL." unless Addressable::URI.parse(url)
-    repo_name = File.basename(url, ".*")
+    if name != ''
+        repo_name = name
+    else 
+        repo_name = File.basename(url, ".*")
+    end
     repo_path = File.join(REPOS_ROOT, repo_name)
     raise "There is already a folder named \"#{repo_name}\" in #{REPOS_ROOT}." if File.exists?(repo_path)
     Resque.enqueue(CloneNewRepo, repo_name, url)

--- a/lib/api_routes.rb
+++ b/lib/api_routes.rb
@@ -32,7 +32,7 @@ class BarkeepServer < Sinatra::Base
   post "/api/add_repo" do
     ensure_required_params :url
     begin
-      add_repo params[:url]
+      add_repo params[:url], params[:name]
     rescue RuntimeError => e
       api_error 400, e.message
     end

--- a/public/coffee/repos.coffee
+++ b/public/coffee/repos.coffee
@@ -2,10 +2,11 @@ window.Repos =
   init: ->
     $("button#clone").click =>
       repoUrl = $("#newRepoUrl").val()
+      repoName = $("#newRepoName").val()
       $.ajax
         type: "post"
         url: "/admin/repos/create_new_repo"
-        data: { url: repoUrl }
+        data: { url: repoUrl, name: repoName }
         dataType: "json"
         success: => @showConfirmationMessage("#{repoUrl} has been scheduled to be cloned.")
         error: (response) => @showConfirmationMessage(response.responseText)

--- a/views/admin/repos.erb
+++ b/views/admin/repos.erb
@@ -15,9 +15,12 @@
   <h2>Add new repo</h2>
   <div id="cloneForm">
     <label for="newRepoUrl">Repo url</label><br/>
-    <input type="text" id="newRepoUrl" />
+    <input type="text" id="newRepoUrl" /><br>
+    <label for="newRepoName">Repo Name</label><br/>
+    <input type="text" id="newRepoName" />
     <button id="clone" class="standard">Add repo</button><br/>
     <span class="note">e.g. http://github.com/ooyala/barkeep.git</span><br/>
+    <span class="note">Repo name should be letters and number - no spaces or punctuation </span><br>
     <p class="note">This repo will be cloned into <code><%= REPOS_ROOT %></code></p>
   </div>
 


### PR DESCRIPTION
We frequently have the same folder name for our git repos (/home/projectA/project.git, home/projectB/project.git etc...) so auto naming the repository seemed like a problem for us. 

I added a name field to change the repo name when adding. Some additional validation on the name field would probably be good - but I'm not much of a ruby guy so that might be better left to the professionals. 
