### PR TITLE
Encode Text as UTF-8 before highlighting (fixes #468)

### DIFF
--- a/lib/syntax_highlighter.rb
+++ b/lib/syntax_highlighter.rb
@@ -38,7 +38,7 @@ class SyntaxHighlighter
 
   def self.pygmentize(file_type, text)
     file_type = Pygments::Lexer.find(file_type).then { |lexer| lexer[:aliases][0] rescue nil } || "text"
-    Pygments.highlight(text, :lexer => file_type, :options => {
+    Pygments.highlight(text.to_s.encode('UTF-8', {:invalid => :replace, :undef => :replace, :replace => '?'}), :lexer => file_type, :options => {
       :encoding => "utf-8", :nowrap => true, :stripnl => false, :stripall => false
     })
   end


### PR DESCRIPTION
Prevent UndefinedConversionError on non ASCII-Chars
