### PR TITLE
break install script on error

### DIFF
--- a/install_barkeep.sh
+++ b/install_barkeep.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# force script to stop on error
+set -e
+
 # This script is tested for a clean Ubuntu 10.04 image. It's a starting point for a fresh Barkeep install,
 # but the important dependencies are:
 # - mysql


### PR DESCRIPTION
I've tried the `install_barkeep.sh` script while executing a system update taking the dpkg lock.
The script fails to install dependencies but continues its execution which might fails if system requirements are not met.
