### PR TITLE
fix NoMethodError

### DIFF
--- a/lib/syntax_highlighter.rb
+++ b/lib/syntax_highlighter.rb
@@ -48,7 +48,9 @@ class SyntaxHighlighter
   # NOTE(caleb): It might be possible/better to do this in Python. However, that will probably involve
   # modifying Pygments (monkey-patching isn't so simple in Python) and in general will be more work.
   def self.global_highlighting(pygmentized_text)
-    pygmentized_text.gsub(/[ \t]+$/) { |whitespace| "<span class='trailingWhitespace'>#{whitespace}</span>" }
+    unless pygmentized_text.nil?
+      pygmentized_text.gsub(/[ \t]+$/) { |whitespace| "<span class='trailingWhitespace'>#{whitespace}</span>" }
+    end
   end
 
   def self.redis_cache_key(repo_name, blob)


### PR DESCRIPTION
    NoMethodError - undefined method `gsub' for nil:NilClass:
            barkeep/lib/syntax_highlighter.rb:51:in `global_highlighting'
            barkeep/lib/syntax_highlighter.rb:25:in `colorize_blob'
            barkeep/lib/git_diff_utils.rb:48:in `block in get_tagged_commit_diffs'
            barkeep/lib/git_diff_utils.rb:26:in `map'
            barkeep/lib/git_diff_utils.rb:26:in `get_tagged_commit_diffs'
            barkeep/barkeep_server.rb:327:in `block in <class:BarkeepServer>'