### PR TITLE
Fix stats for unreviewed commits

### DIFF
--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -13,7 +13,7 @@ module Stats
   end
 
   def self.num_unreviewed_commits(since)
-    Commit.filter("`commits`.`date` > ?", since).
+    Commit.filter("`commits`.`date` > ?", since).filter(:approved_by_user_id => nil).
         left_join(:comments, :commit_id => :commits__id).filter(:comments__id => nil).count
   end
 


### PR DESCRIPTION
The stats page pie graphic is showing wrong numbers. When looking into the code one can see that the `unreviewedpercent` is much too high, because it counts approved commits that were not commented.