### PR TITLE
make install script use https instead of git protocol

### DIFF
--- a/install_barkeep.sh
+++ b/install_barkeep.sh
@@ -23,18 +23,18 @@ sudo add-apt-repository -y ppa:git-core/ppa && sudo apt-get update
 sudo apt-get install -y git
 
 # Install ruby 1.9.3-p194
-git clone git://github.com/sstephenson/rbenv.git ~/.rbenv
+git clone https://github.com/sstephenson/rbenv.git ~/.rbenv
 echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.profile
 echo 'eval "$(rbenv init -)"' >> ~/.profile
 source ~/.profile
-git clone git://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
+git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
 rbenv install 1.9.3-p194
 rbenv global 1.9.3-p194
 gem install bundler
 rbenv rehash
 
 # Clone Barkeep
-git clone git://github.com/ooyala/barkeep.git ~/barkeep
+git clone https://github.com/ooyala/barkeep.git ~/barkeep
 cd ~/barkeep && bundle install && rbenv rehash
 
 # Configure a reverse proxy webserver (nginx) to Barkeep


### PR DESCRIPTION
Me and other people have firewall restrictions which causes this script to fail when running git clone commands that use the git protocol. I suggest instead that we use https. Technically, it will also verify that you got the repository code from the correct server as well. See this link for details: https://gist.github.com/grawity/4392747
